### PR TITLE
Add extension to dispatch attributed actions from publishers

### DIFF
--- a/Mini.xcodeproj/project.pbxproj
+++ b/Mini.xcodeproj/project.pbxproj
@@ -100,14 +100,18 @@
 		F227FD8229CDB3F800F1E801 /* AttributedAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8029CDB3F800F1E801 /* AttributedAction.swift */; };
 		F227FD8329CDB3F800F1E801 /* AttributedAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8029CDB3F800F1E801 /* AttributedAction.swift */; };
 		F227FD8429CDB3F800F1E801 /* AttributedAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8029CDB3F800F1E801 /* AttributedAction.swift */; };
+		F227FD8729CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8629CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift */; };
+		F227FD8829CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8629CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift */; };
+		F227FD8929CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8629CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift */; };
+		F227FD8A29CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227FD8629CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift */; };
 		F26C3AF822537A4600189D28 /* Mini.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* Mini.swift */; };
 		F26C3AF922537A4600189D28 /* Mini.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* Mini.swift */; };
 		F26C3AFA22537A4600189D28 /* Mini.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* Mini.swift */; };
 		F26C3AFB22537A4600189D28 /* Mini.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* Mini.swift */; };
-		F288761028649AFE0069790E /* PublisherExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions.swift */; };
-		F288761128649AFE0069790E /* PublisherExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions.swift */; };
-		F288761228649AFE0069790E /* PublisherExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions.swift */; };
-		F288761328649AFE0069790E /* PublisherExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions.swift */; };
+		F288761028649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions+CompletableActions.swift */; };
+		F288761128649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions+CompletableActions.swift */; };
+		F288761228649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions+CompletableActions.swift */; };
+		F288761328649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288760F28649AFE0069790E /* PublisherExtensions+CompletableActions.swift */; };
 		F288761528649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288761428649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift */; };
 		F288761628649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288761428649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift */; };
 		F288761728649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F288761428649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift */; };
@@ -228,8 +232,9 @@
 		F222D7692525361700672E7B /* KeyedTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedTask.swift; sourceTree = "<group>"; };
 		F222D7752525373B00672E7B /* KeyedTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedTaskTests.swift; sourceTree = "<group>"; };
 		F227FD8029CDB3F800F1E801 /* AttributedAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedAction.swift; sourceTree = "<group>"; };
+		F227FD8629CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublisherExtensions+EmptyActions.swift"; sourceTree = "<group>"; };
 		F26C3AF722537A4600189D28 /* Mini.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mini.swift; sourceTree = "<group>"; };
-		F288760F28649AFE0069790E /* PublisherExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherExtensions.swift; sourceTree = "<group>"; };
+		F288760F28649AFE0069790E /* PublisherExtensions+CompletableActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublisherExtensions+CompletableActions.swift"; sourceTree = "<group>"; };
 		F288761428649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.CombineMiniTasksTuple2.swift; sourceTree = "<group>"; };
 		F288DCC829BA8BF600FBFED1 /* None.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = None.swift; sourceTree = "<group>"; };
 		F288DCCE29BB922700FBFED1 /* Publishers.CombineMiniTasksTuple4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.CombineMiniTasksTuple4.swift; sourceTree = "<group>"; };
@@ -417,7 +422,8 @@
 			isa = PBXGroup;
 			children = (
 				F297D27D286A0C6900323F24 /* Dispatcher+Combine.swift */,
-				F288760F28649AFE0069790E /* PublisherExtensions.swift */,
+				F288760F28649AFE0069790E /* PublisherExtensions+CompletableActions.swift */,
+				F227FD8629CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift */,
 				F288DCD829BB942100FBFED1 /* Publishers.CombineMiniTasksArray.swift */,
 				F288761428649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift */,
 				F288DCD329BB922F00FBFED1 /* Publishers.CombineMiniTasksTuple3.swift */,
@@ -772,8 +778,9 @@
 				F297D27E286A0C6900323F24 /* Dispatcher+Combine.swift in Sources */,
 				F288761528649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */,
 				F297D269286A02E200323F24 /* KeyedAction.swift in Sources */,
+				F227FD8729CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */,
 				F222D4B325249B7E00672E7B /* Task.swift in Sources */,
-				F288761028649AFE0069790E /* PublisherExtensions.swift in Sources */,
+				F288761028649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */,
 				F288DCC929BA8BF600FBFED1 /* None.swift in Sources */,
 				F222D4CF25249B7E00672E7B /* Store.swift in Sources */,
 				F288DCCF29BB922700FBFED1 /* Publishers.CombineMiniTasksTuple4.swift in Sources */,
@@ -828,8 +835,9 @@
 				F297D27F286A0C6900323F24 /* Dispatcher+Combine.swift in Sources */,
 				F288761628649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */,
 				F297D26A286A02E200323F24 /* KeyedAction.swift in Sources */,
+				F227FD8829CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */,
 				F222D4B425249B7E00672E7B /* Task.swift in Sources */,
-				F288761128649AFE0069790E /* PublisherExtensions.swift in Sources */,
+				F288761128649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */,
 				F288DCCA29BA8BF600FBFED1 /* None.swift in Sources */,
 				F222D4D025249B7E00672E7B /* Store.swift in Sources */,
 				F288DCD029BB922700FBFED1 /* Publishers.CombineMiniTasksTuple4.swift in Sources */,
@@ -884,8 +892,9 @@
 				F297D280286A0C6900323F24 /* Dispatcher+Combine.swift in Sources */,
 				F288761728649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */,
 				F297D26B286A02E200323F24 /* KeyedAction.swift in Sources */,
+				F227FD8929CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */,
 				F222D4B525249B7E00672E7B /* Task.swift in Sources */,
-				F288761228649AFE0069790E /* PublisherExtensions.swift in Sources */,
+				F288761228649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */,
 				F288DCCB29BA8BF600FBFED1 /* None.swift in Sources */,
 				F222D4D125249B7E00672E7B /* Store.swift in Sources */,
 				F288DCD129BB922700FBFED1 /* Publishers.CombineMiniTasksTuple4.swift in Sources */,
@@ -940,8 +949,9 @@
 				F297D281286A0C6900323F24 /* Dispatcher+Combine.swift in Sources */,
 				F288761828649B1C0069790E /* Publishers.CombineMiniTasksTuple2.swift in Sources */,
 				F297D26C286A02E200323F24 /* KeyedAction.swift in Sources */,
+				F227FD8A29CDEBAE00F1E801 /* PublisherExtensions+EmptyActions.swift in Sources */,
 				F222D4B625249B7E00672E7B /* Task.swift in Sources */,
-				F288761328649AFE0069790E /* PublisherExtensions.swift in Sources */,
+				F288761328649AFE0069790E /* PublisherExtensions+CompletableActions.swift in Sources */,
 				F288DCCC29BA8BF600FBFED1 /* None.swift in Sources */,
 				F222D4D225249B7E00672E7B /* Store.swift in Sources */,
 				F288DCD229BB922700FBFED1 /* Publishers.CombineMiniTasksTuple4.swift in Sources */,

--- a/Sources/Publishers/PublisherExtensions+CompletableActions.swift
+++ b/Sources/Publishers/PublisherExtensions+CompletableActions.swift
@@ -1,0 +1,63 @@
+import Combine
+import Foundation
+
+public extension Publisher {
+    func dispatch<A: CompletableAction>(action: A.Type,
+                                        expiration: TaskExpiration = .immediately,
+                                        on dispatcher: Dispatcher)
+    -> Cancellable where A.TaskPayload == Output, A.TaskError == Failure {
+        sink { completion in
+            switch completion {
+            case .failure(let error):
+                let action = A(task: .requestFailure(error))
+                dispatcher.dispatch(action)
+
+            case .finished:
+                break
+            }
+        } receiveValue: { payload in
+            let action = A(task: .requestSuccess(payload, expiration: expiration))
+            dispatcher.dispatch(action)
+        }
+    }
+
+    func dispatch<A: KeyedCompletableAction>(action: A.Type,
+                                             expiration: TaskExpiration = .immediately,
+                                             key: A.Key,
+                                             on dispatcher: Dispatcher)
+    -> Cancellable where A.TaskPayload == Output, A.TaskError == Failure {
+        sink { completion in
+            switch completion {
+            case .failure(let error):
+                let action = A(task: .requestFailure(error, tag: "\(key)"), key: key)
+                dispatcher.dispatch(action)
+
+            case .finished:
+                break
+            }
+        } receiveValue: { payload in
+            let action = A(task: .requestSuccess(payload, tag: "\(key)"), key: key)
+            dispatcher.dispatch(action)
+        }
+    }
+
+    func dispatch<A: AttributedCompletableAction>(action: A.Type,
+                                                  attribute: A.Attribute,
+                                                  expiration: TaskExpiration = .immediately,
+                                                  on dispatcher: Dispatcher)
+    -> Cancellable where A.TaskPayload == Output, A.TaskError == Failure {
+        sink { completion in
+            switch completion {
+            case .failure(let error):
+                let action = A(task: .requestFailure(error), attribute: attribute)
+                dispatcher.dispatch(action)
+
+            case .finished:
+                break
+            }
+        } receiveValue: { payload in
+            let action = A(task: .requestSuccess(payload, expiration: expiration), attribute: attribute)
+            dispatcher.dispatch(action)
+        }
+    }
+}

--- a/Sources/Publishers/PublisherExtensions+EmptyActions.swift
+++ b/Sources/Publishers/PublisherExtensions+EmptyActions.swift
@@ -2,45 +2,6 @@ import Combine
 import Foundation
 
 public extension Publisher {
-    func dispatch<A: CompletableAction>(action: A.Type,
-                                        expiration: TaskExpiration = .immediately,
-                                        on dispatcher: Dispatcher)
-    -> Cancellable where A.TaskPayload == Output, A.TaskError == Failure {
-        sink { completion in
-            switch completion {
-            case .failure(let error):
-                let action = A(task: .requestFailure(error))
-                dispatcher.dispatch(action)
-
-            case .finished:
-                break
-            }
-        } receiveValue: { payload in
-            let action = A(task: .requestSuccess(payload, expiration: expiration))
-            dispatcher.dispatch(action)
-        }
-    }
-
-    func dispatch<A: KeyedCompletableAction>(action: A.Type,
-                                             expiration: TaskExpiration = .immediately,
-                                             key: A.Key,
-                                             on dispatcher: Dispatcher)
-    -> Cancellable where A.TaskPayload == Output, A.TaskError == Failure {
-        sink { completion in
-            switch completion {
-            case .failure(let error):
-                let action = A(task: .requestFailure(error, tag: "\(key)"), key: key)
-                dispatcher.dispatch(action)
-
-            case .finished:
-                break
-            }
-        } receiveValue: { payload in
-            let action = A(task: .requestSuccess(payload, tag: "\(key)"), key: key)
-            dispatcher.dispatch(action)
-        }
-    }
-
     func dispatch<A: KeyedEmptyAction>(action: A.Type,
                                        expiration: TaskExpiration = .immediately,
                                        key: A.Key,
@@ -109,6 +70,44 @@ public extension Publisher {
 
             case .finished:
                 let action = A(task: .requestSuccess(expiration: expiration))
+                dispatcher.dispatch(action)
+            }
+        } receiveValue: { _ in
+        }
+    }
+
+    func dispatch<A: AttributedEmptyAction>(action: A.Type,
+                                            attribute: A.Attribute,
+                                            expiration: TaskExpiration = .immediately,
+                                            on dispatcher: Dispatcher)
+    -> Cancellable where A.TaskPayload == Output, A.TaskError == Failure, Output == None {
+        sink { completion in
+            switch completion {
+            case .failure(let error):
+                let action = A(task: .requestFailure(error), attribute: attribute)
+                dispatcher.dispatch(action)
+
+            case .finished:
+                let action = A(task: .requestSuccess(expiration: expiration), attribute: attribute)
+                dispatcher.dispatch(action)
+            }
+        } receiveValue: { _ in
+        }
+    }
+
+    func dispatch<A: AttributedEmptyAction>(action: A.Type,
+                                            attribute: A.Attribute,
+                                            expiration: TaskExpiration = .immediately,
+                                            on dispatcher: Dispatcher)
+    -> Cancellable where A.TaskPayload == None, A.TaskError == Failure, Output == Void {
+        sink { completion in
+            switch completion {
+            case .failure(let error):
+                let action = A(task: .requestFailure(error), attribute: attribute)
+                dispatcher.dispatch(action)
+
+            case .finished:
+                let action = A(task: .requestSuccess(expiration: expiration), attribute: attribute)
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in

--- a/Tests/DispatcherTests.swift
+++ b/Tests/DispatcherTests.swift
@@ -150,6 +150,55 @@ final class DispatcherTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
+    func test_send_attributedcompletableaction_to_dispatcher_from_future() {
+        let dispatcher = Dispatcher()
+        let expectedPayload = "hi!"
+        let expectedError = TestError.berenjenaError
+        var cancellables = Set<AnyCancellable>()
+
+        let futureSuccess = Future<String, TestError> { promise in
+            promise(.success(expectedPayload))
+        }
+        let futureFailure = Future<String, TestError> { promise in
+            promise(.failure(.berenjenaError))
+        }
+
+        // CHECK:
+        let expectationSuccess = expectation(description: "wait for action dispatched with task success")
+        let expectationFailure = expectation(description: "wait for action dispatched with task error")
+
+        dispatcher
+            .subscribe { (action: TestAttributedCompletableAction) in
+                switch action.task.status {
+                case .success(let payload):
+                    if payload == expectedPayload {
+                        expectationSuccess.fulfill()
+                    }
+
+                case .failure(let error):
+                    if error == expectedError {
+                        expectationFailure.fulfill()
+                    }
+
+                default:
+                    XCTFail("bad action received: \(action)")
+                }
+
+                XCTAssertEqual(action.attribute, "hola")
+            }
+            .store(in: &cancellables)
+
+        // SEND!
+        futureSuccess
+            .dispatch(action: TestAttributedCompletableAction.self, attribute: "hola", on: dispatcher)
+            .store(in: &cancellables)
+        futureFailure
+            .dispatch(action: TestAttributedCompletableAction.self, attribute: "hola", on: dispatcher)
+            .store(in: &cancellables)
+
+        waitForExpectations(timeout: 10)
+    }
+
     func test_send_emptyaction_to_dispatcher_from_none_future() {
         let dispatcher = Dispatcher()
         let expectedError = TestError.berenjenaError
@@ -323,6 +372,98 @@ final class DispatcherTests: XCTestCase {
             .store(in: &cancellables)
         futureFailure
             .dispatch(action: TestKeyedEmptyAction.self, key: expectedKey, on: dispatcher)
+            .store(in: &cancellables)
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_send_attributedemptyaction_to_dispatcher_from_none_future() {
+        let dispatcher = Dispatcher()
+        let expectedError = TestError.berenjenaError
+        var cancellables = Set<AnyCancellable>()
+
+        let futureSuccess = Future<None, TestError> { promise in
+            promise(.success(.none))
+        }
+        let futureFailure = Future<None, TestError> { promise in
+            promise(.failure(.berenjenaError))
+        }
+
+        // CHECK:
+        let expectationSuccess = expectation(description: "wait for action dispatched with task success")
+        let expectationFailure = expectation(description: "wait for action dispatched with task error")
+
+        dispatcher
+            .subscribe { (action: TestAttributedEmptyAction) in
+                switch action.task.status {
+                case .success:
+                    expectationSuccess.fulfill()
+
+                case .failure(let error):
+                    if error == expectedError {
+                        expectationFailure.fulfill()
+                    }
+
+                default:
+                    XCTFail("bad action received: \(action)")
+                }
+
+                XCTAssertEqual(action.attribute, "hola")
+            }
+            .store(in: &cancellables)
+
+        // SEND!
+        futureSuccess
+            .dispatch(action: TestAttributedEmptyAction.self, attribute: "hola", on: dispatcher)
+            .store(in: &cancellables)
+        futureFailure
+            .dispatch(action: TestAttributedEmptyAction.self, attribute: "hola", on: dispatcher)
+            .store(in: &cancellables)
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_send_attributedemptyaction_to_dispatcher_from_void_future() {
+        let dispatcher = Dispatcher()
+        let expectedError = TestError.berenjenaError
+        var cancellables = Set<AnyCancellable>()
+
+        let futureSuccess = Future<Void, TestError> { promise in
+            promise(.success(()))
+        }
+        let futureFailure = Future<Void, TestError> { promise in
+            promise(.failure(.berenjenaError))
+        }
+
+        // CHECK:
+        let expectationSuccess = expectation(description: "wait for action dispatched with task success")
+        let expectationFailure = expectation(description: "wait for action dispatched with task error")
+
+        dispatcher
+            .subscribe { (action: TestAttributedEmptyAction) in
+                switch action.task.status {
+                case .success:
+                    expectationSuccess.fulfill()
+
+                case .failure(let error):
+                    if error == expectedError {
+                        expectationFailure.fulfill()
+                    }
+
+                default:
+                    XCTFail("bad action received: \(action)")
+                }
+
+                XCTAssertEqual(action.attribute, "hola")
+            }
+            .store(in: &cancellables)
+
+        // SEND!
+        futureSuccess
+            .dispatch(action: TestAttributedEmptyAction.self, attribute: "hola", on: dispatcher)
+            .store(in: &cancellables)
+        futureFailure
+            .dispatch(action: TestAttributedEmptyAction.self, attribute: "hola", on: dispatcher)
             .store(in: &cancellables)
 
         waitForExpectations(timeout: 10)

--- a/Tests/Helpers/TestActions.swift
+++ b/Tests/Helpers/TestActions.swift
@@ -102,3 +102,44 @@ class TestAttributedAction: AttributedAction {
         return true
     }
 }
+
+class TestAttributedEmptyAction: AttributedEmptyAction {
+    typealias TaskError = TestError
+    typealias Attribute = String
+
+    let attribute: Attribute
+    let task: EmptyTask<TaskError>
+
+    required init(task: EmptyTask<TaskError>, attribute: Attribute) {
+        self.attribute = attribute
+        self.task = task
+    }
+
+    func isEqual(to other: Action) -> Bool {
+        guard let action = other as? TestAttributedEmptyAction else { return false }
+        guard attribute == action.attribute else { return false }
+        guard task == action.task else { return false }
+        return true
+    }
+}
+
+class TestAttributedCompletableAction: AttributedCompletableAction {
+    typealias TaskPayload = String
+    typealias TaskError = TestError
+    typealias Attribute = String
+
+    let attribute: Attribute
+    let task: Task<TaskPayload, TaskError>
+
+    required init(task: Task<TaskPayload, TaskError>, attribute: Attribute) {
+        self.attribute = attribute
+        self.task = task
+    }
+
+    func isEqual(to other: Action) -> Bool {
+        guard let action = other as? TestAttributedCompletableAction else { return false }
+        guard attribute == action.attribute else { return false }
+        guard task == action.task else { return false }
+        return true
+    }
+}


### PR DESCRIPTION
### PR's key points
Add .dispatch extension to dispatch from a publisher directly to `AttributedEmptyAction` & `AttributedCompletableAction`
