### PR TITLE
Simplify naming for task helpers

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -39,7 +39,7 @@ jobs:
       run: arch -arm64 bundle exec fastlane test_scheme scheme:Mini-iOS configuration:Debug name:iOS
 
     - name: Upload coverage for iOS to Codecov 📋
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         xcode: true
@@ -53,7 +53,7 @@ jobs:
       run: arch -arm64 bundle exec fastlane test_scheme scheme:Mini-tvOS configuration:Debug name:tv
 
     - name: Upload coverage for tvOS to Codecov 📋
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         xcode: true
@@ -67,7 +67,7 @@ jobs:
       run: arch -arm64 bundle exec fastlane test_scheme scheme:Mini-macOS configuration:Debug name:mac
 
     - name: Upload coverage for mac to Codecov 📋
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         xcode: true

--- a/Sources/Dispatcher.swift
+++ b/Sources/Dispatcher.swift
@@ -3,13 +3,6 @@ import Foundation
 public typealias SubscriptionMap = SharedDictionary<String, OrderedSet<DispatcherSubscription>?>
 
 public final class Dispatcher {
-    public struct DispatchMode {
-        // swiftlint:disable:next type_name
-        public enum UI {
-            case sync, async
-        }
-    }
-
     public var subscriptionCount: Int {
         subscriptionMap.innerDictionary.mapValues { set -> Int in
             guard let setValue = set else { return 0 }
@@ -121,25 +114,6 @@ public final class Dispatcher {
 
     public func subscribe(tag: String, completion: @escaping (Action) -> Void) -> DispatcherSubscription {
         subscribe(priority: Dispatcher.defaultPriority, tag: tag, completion: completion)
-    }
-
-    @available(*, deprecated, message: "Dont set mode. Use dispatch(_). In the near future all actions will be dispatched asynchronously")
-    public func dispatch(_ action: Action, mode: Dispatcher.DispatchMode.UI) {
-         switch mode {
-         case .sync:
-             if DispatchQueue.isMain {
-                 self.dispatchOnQueue(action)
-             } else {
-                 DispatchQueue.main.sync {
-                     self.dispatchOnQueue(action)
-                 }
-             }
-
-         case .async:
-             DispatchQueue.main.async {
-                 self.dispatchOnQueue(action)
-             }
-         }
     }
 
     public func dispatch(_ action: Action) {

--- a/Sources/Extensions/DictionaryExtensions.swift
+++ b/Sources/Extensions/DictionaryExtensions.swift
@@ -7,11 +7,6 @@ public extension Dictionary {
         self[key, ifNotExistsSave: defaultValue()]
     }
 
-    @available(*, deprecated, renamed: "safeValue")
-    mutating func getOrPut(_ key: Key, defaultValue: () -> Value) -> Value {
-        self[key, ifNotExistsSave: defaultValue()]
-    }
-
     subscript (_ key: Key, ifNotExistsSave value: @autoclosure () -> Value) -> Value {
         mutating get {
             if let value = self[key] {

--- a/Sources/Publishers/PublisherExtensions+CompletableActions.swift
+++ b/Sources/Publishers/PublisherExtensions+CompletableActions.swift
@@ -9,14 +9,14 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error))
+                let action = A(task: .failure(error))
                 dispatcher.dispatch(action)
 
             case .finished:
                 break
             }
         } receiveValue: { payload in
-            let action = A(task: .requestSuccess(payload, expiration: expiration))
+            let action = A(task: .success(payload, expiration: expiration))
             dispatcher.dispatch(action)
         }
     }
@@ -29,14 +29,14 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error, tag: "\(key)"), key: key)
+                let action = A(task: .failure(error, tag: "\(key)"), key: key)
                 dispatcher.dispatch(action)
 
             case .finished:
                 break
             }
         } receiveValue: { payload in
-            let action = A(task: .requestSuccess(payload, tag: "\(key)"), key: key)
+            let action = A(task: .success(payload, tag: "\(key)"), key: key)
             dispatcher.dispatch(action)
         }
     }
@@ -49,14 +49,14 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error), attribute: attribute)
+                let action = A(task: .failure(error), attribute: attribute)
                 dispatcher.dispatch(action)
 
             case .finished:
                 break
             }
         } receiveValue: { payload in
-            let action = A(task: .requestSuccess(payload, expiration: expiration), attribute: attribute)
+            let action = A(task: .success(payload, expiration: expiration), attribute: attribute)
             dispatcher.dispatch(action)
         }
     }

--- a/Sources/Publishers/PublisherExtensions+EmptyActions.swift
+++ b/Sources/Publishers/PublisherExtensions+EmptyActions.swift
@@ -10,11 +10,11 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error), key: key)
+                let action = A(task: .failure(error), key: key)
                 dispatcher.dispatch(action)
 
             case .finished:
-                let action = A(task: .requestSuccess(expiration: expiration, tag: "\(key)"), key: key)
+                let action = A(task: .success(expiration: expiration, tag: "\(key)"), key: key)
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in
@@ -29,11 +29,11 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error), key: key)
+                let action = A(task: .failure(error), key: key)
                 dispatcher.dispatch(action)
 
             case .finished:
-                let action = A(task: .requestSuccess(expiration: expiration, tag: "\(key)"), key: key)
+                let action = A(task: .success(expiration: expiration, tag: "\(key)"), key: key)
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in
@@ -47,11 +47,11 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error))
+                let action = A(task: .failure(error))
                 dispatcher.dispatch(action)
 
             case .finished:
-                let action = A(task: .requestSuccess(expiration: expiration))
+                let action = A(task: .success(expiration: expiration))
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in
@@ -65,11 +65,11 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error))
+                let action = A(task: .failure(error))
                 dispatcher.dispatch(action)
 
             case .finished:
-                let action = A(task: .requestSuccess(expiration: expiration))
+                let action = A(task: .success(expiration: expiration))
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in
@@ -84,11 +84,11 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error), attribute: attribute)
+                let action = A(task: .failure(error), attribute: attribute)
                 dispatcher.dispatch(action)
 
             case .finished:
-                let action = A(task: .requestSuccess(expiration: expiration), attribute: attribute)
+                let action = A(task: .success(expiration: expiration), attribute: attribute)
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in
@@ -103,11 +103,11 @@ public extension Publisher {
         sink { completion in
             switch completion {
             case .failure(let error):
-                let action = A(task: .requestFailure(error), attribute: attribute)
+                let action = A(task: .failure(error), attribute: attribute)
                 dispatcher.dispatch(action)
 
             case .finished:
-                let action = A(task: .requestSuccess(expiration: expiration), attribute: attribute)
+                let action = A(task: .success(expiration: expiration), attribute: attribute)
                 dispatcher.dispatch(action)
             }
         } receiveValue: { _ in

--- a/Sources/Publishers/Publishers.CombineMiniTasksArray.swift
+++ b/Sources/Publishers/Publishers.CombineMiniTasksArray.swift
@@ -46,20 +46,20 @@ extension Publishers.CombineMiniTasksArray {
             }
 
             if tasks.map({ $0.isRunning }).contains(true) {
-                return downstream.receive(.requestRunning())
+                return downstream.receive(.running())
             }
 
             if let failureTask = tasks.first(where: { $0.isFailure }), let failure = failureTask.error as? Output.Failure {
-                return downstream.receive(.requestFailure(failure))
+                return downstream.receive(.failure(failure))
             }
 
             if
                 !tasks.map({ $0.isSuccessful }).contains(false),
                 let payload = tasks.compactMap({ $0.payload }) as? TaskPayload {
-                return downstream.receive(.requestSuccess(payload))
+                return downstream.receive(.success(payload))
             }
 
-            return downstream.receive(.requestIdle())
+            return downstream.receive(.idle())
         }
 
         func receive(completion: Subscribers.Completion<Upstream.Failure>) {

--- a/Sources/Publishers/Publishers.CombineMiniTasksTuple2.swift
+++ b/Sources/Publishers/Publishers.CombineMiniTasksTuple2.swift
@@ -66,7 +66,7 @@ extension Publishers.CombineMiniTasksTuple2 {
             }
 
             if tuple.0.isRunning || tuple.1.isRunning {
-                return downstream.receive(.requestRunning())
+                return downstream.receive(.running())
             }
 
             if
@@ -74,7 +74,7 @@ extension Publishers.CombineMiniTasksTuple2 {
                 let failure = tuple.0.error as? Output.Failure ??
                     tuple.1.error as? Output.Failure
             {
-                return downstream.receive(.requestFailure(failure))
+                return downstream.receive(.failure(failure))
             }
 
             if
@@ -83,10 +83,10 @@ extension Publishers.CombineMiniTasksTuple2 {
                 let payload2 = tuple.1.payload as? TaskPayload.T2Payload,
                 let payload = TaskTuple2Payload(payload1, payload2) as? TaskPayload
             {
-                return downstream.receive(.requestSuccess(payload))
+                return downstream.receive(.success(payload))
             }
 
-            return downstream.receive(.requestIdle())
+            return downstream.receive(.idle())
         }
 
         func receive(completion: Subscribers.Completion<Upstream.Failure>) {

--- a/Sources/Publishers/Publishers.CombineMiniTasksTuple3.swift
+++ b/Sources/Publishers/Publishers.CombineMiniTasksTuple3.swift
@@ -70,7 +70,7 @@ extension Publishers.CombineMiniTasksTuple3 {
             }
 
             if tuple.0.isRunning || tuple.1.isRunning || tuple.2.isRunning {
-                return downstream.receive(.requestRunning())
+                return downstream.receive(.running())
             }
 
             if
@@ -79,7 +79,7 @@ extension Publishers.CombineMiniTasksTuple3 {
                     tuple.1.error as? Output.Failure ??
                     tuple.2.error as? Output.Failure
             {
-                return downstream.receive(.requestFailure(failure))
+                return downstream.receive(.failure(failure))
             }
 
             if
@@ -89,10 +89,10 @@ extension Publishers.CombineMiniTasksTuple3 {
                 let payload3 = tuple.2.payload as? TaskPayload.T3Payload,
                 let payload = TaskTuple3Payload(payload1, payload2, payload3) as? TaskPayload
             {
-                return downstream.receive(.requestSuccess(payload))
+                return downstream.receive(.success(payload))
             }
 
-            return downstream.receive(.requestIdle())
+            return downstream.receive(.idle())
         }
 
         func receive(completion: Subscribers.Completion<Upstream.Failure>) {

--- a/Sources/Publishers/Publishers.CombineMiniTasksTuple4.swift
+++ b/Sources/Publishers/Publishers.CombineMiniTasksTuple4.swift
@@ -74,7 +74,7 @@ extension Publishers.CombineMiniTasksTuple4 {
             }
 
             if tuple.0.isRunning || tuple.1.isRunning || tuple.2.isRunning || tuple.3.isRunning {
-                return downstream.receive(.requestRunning())
+                return downstream.receive(.running())
             }
 
             if
@@ -84,7 +84,7 @@ extension Publishers.CombineMiniTasksTuple4 {
                     tuple.2.error as? Output.Failure ??
                     tuple.3.error as? Output.Failure
             {
-                return downstream.receive(.requestFailure(failure))
+                return downstream.receive(.failure(failure))
             }
 
             if
@@ -95,10 +95,10 @@ extension Publishers.CombineMiniTasksTuple4 {
                 let payload4 = tuple.3.payload as? TaskPayload.T4Payload,
                 let payload = TaskTuple4Payload(payload1, payload2, payload3, payload4) as? TaskPayload
             {
-                return downstream.receive(.requestSuccess(payload))
+                return downstream.receive(.success(payload))
             }
 
-            return downstream.receive(.requestIdle())
+            return downstream.receive(.idle())
         }
 
         func receive(completion: Subscribers.Completion<Upstream.Failure>) {

--- a/Sources/Publishers/Publishers.EraseToEmptyTask.swift
+++ b/Sources/Publishers/Publishers.EraseToEmptyTask.swift
@@ -43,16 +43,16 @@ extension Publishers.EraseToEmptyTask {
         func receive(_ input: Upstream.Output) -> Subscribers.Demand {
             switch input.status {
             case .success:
-                return downstream.receive(.requestSuccess())
+                return downstream.receive(.success())
 
             case .idle:
-                return downstream.receive(.requestIdle())
+                return downstream.receive(.idle())
 
             case .running:
-                return downstream.receive(.requestRunning())
+                return downstream.receive(.running())
 
             case .failure(let error):
-                return downstream.receive(.requestFailure(error))
+                return downstream.receive(.failure(error))
             }
         }
 

--- a/Sources/Task/Task.swift
+++ b/Sources/Task/Task.swift
@@ -29,6 +29,8 @@ public class Task<T: Equatable, E: Error & Equatable>: TaskType, Equatable, Cust
     public let tag: String?
     public let progress: Decimal?
 
+    // TODO: This init should be private in the near future
+    @available(*, deprecated, message: "Use static methods instead .idle(), .running(), .success() or .failure()")
     public required init(status: TaskStatus<Payload, Failure> = .idle,
                          started: Date = Date(),
                          expiration: TaskExpiration = .immediately,
@@ -109,20 +111,64 @@ public class Task<T: Equatable, E: Error & Equatable>: TaskType, Equatable, Cust
         }
     }
 
+    @available(*, deprecated, renamed: "idle")
     public static func requestIdle(tag: String? = nil) -> Self {
-        .init(status: .idle, tag: tag)
+        .idle(tag: tag)
     }
 
+    @available(*, deprecated, renamed: "running")
     public static func requestRunning(tag: String? = nil) -> Self {
-        .init(status: .running, tag: tag)
+        .running(tag: tag)
     }
 
+    @available(*, deprecated, renamed: "failure")
     public static func requestFailure(_ error: Failure, tag: String? = nil) -> Self {
-        .init(status: .failure(error: error), tag: tag)
+        .failure(error, tag: tag)
     }
 
+    @available(*, deprecated, renamed: "success")
     public static func requestSuccess(_ payload: Payload, expiration: TaskExpiration = .immediately, tag: String? = nil) -> Self {
-        .init(status: .success(payload: payload), expiration: expiration, tag: tag)
+        .success(payload, expiration: expiration, tag: tag)
+    }
+
+    public static func idle(started: Date = Date(),
+                            tag: String? = nil,
+                            progress: Decimal? = nil) -> Self {
+        .init(status: .idle,
+              started: started,
+              tag: tag,
+              progress: progress)
+    }
+
+    public static func running(started: Date = Date(),
+                               tag: String? = nil,
+                               progress: Decimal? = nil) -> Self {
+        .init(status: .running,
+              started: started,
+              tag: tag,
+              progress: progress)
+    }
+
+    public static func failure(_ error: Failure,
+                               started: Date = Date(),
+                               tag: String? = nil,
+                               progress: Decimal? = nil) -> Self {
+        .init(status: .failure(error: error),
+              started: started,
+              tag: tag,
+              progress: progress)
+    }
+
+    public static func success(_ payload: Payload,
+                               started: Date = Date(),
+                               expiration: TaskExpiration = .immediately,
+                               tag: String? = nil,
+                               progress: Decimal? = nil) -> Self {
+        .init(status: .success(payload: payload),
+              started: started,
+              expiration: expiration,
+              tag: tag,
+              progress: progress)
     }
 
     // MARK: - CustomDebugStringConvertible

--- a/Sources/Task/Task.swift
+++ b/Sources/Task/Task.swift
@@ -193,7 +193,19 @@ public class Task<T: Equatable, E: Error & Equatable>: TaskType, Equatable, Cust
 }
 
 public extension Task where T == None {
+    static func success(started: Date = Date(),
+                        expiration: TaskExpiration = .immediately,
+                        tag: String? = nil,
+                        progress: Decimal? = nil) -> Self {
+        .init(status: .success(payload: .none),
+              started: started,
+              expiration: expiration,
+              tag: tag,
+              progress: progress)
+    }
+
+    @available(*, deprecated, renamed: "success")
     static func requestSuccess(expiration: TaskExpiration = .immediately, tag: String? = nil) -> Self {
-        .init(status: .success(payload: .none), expiration: expiration, tag: tag)
+        .success(expiration: expiration, tag: tag)
     }
 }

--- a/Tests/ActionTests.swift
+++ b/Tests/ActionTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class ActionTests: XCTestCase {
     func test_actions() {
-        let payloadTask = Task<String, TestError>.requestIdle()
-        let emptyTask = EmptyTask<TestError>.requestRunning()
+        let payloadTask: Task<String, TestError> = .idle()
+        let emptyTask: EmptyTask<TestError> = .running()
 
         let emptyAction = TestEmptyAction(task: emptyTask)
         XCTAssertEqual(emptyAction.task, emptyTask)

--- a/Tests/Helpers/TestState.swift
+++ b/Tests/Helpers/TestState.swift
@@ -5,7 +5,7 @@ struct TestState: StateType {
     public let testTask: Task<None, TestError>
     public let counter: Int
 
-    public init(testTask: Task<None, TestError> = .requestIdle(),
+    public init(testTask: Task<None, TestError> = .idle(),
                 counter: Int = 0) {
         self.testTask = testTask
         self.counter = counter

--- a/Tests/Helpers/TestStoreController.swift
+++ b/Tests/Helpers/TestStoreController.swift
@@ -13,7 +13,7 @@ extension Store where State == TestState, StoreController == TestStoreController
     func reducerGroup(expectation: XCTestExpectation? = nil) -> ReducerGroup {
         ReducerGroup { [
             Reducer(of: TestAction.self, on: self.dispatcher) { action in
-                self.state = TestState(testTask: .requestSuccess(), counter: action.counter)
+                self.state = TestState(testTask: .success(), counter: action.counter)
                 expectation?.fulfill()
             }
         ]

--- a/Tests/KeyedTaskTests.swift
+++ b/Tests/KeyedTaskTests.swift
@@ -3,17 +3,17 @@ import XCTest
 
 class KeyedTaskTests: XCTestCase {
     var tasks: KeyedTask<Int, String, NSError> {
-        [0: .requestRunning(),
-         1: .requestSuccess("hi"),
-         2: .requestFailure(NSError(domain: "domain", code: 44, userInfo: nil)),
-         3: .requestIdle()]
+        [0: .running(),
+         1: .success("hi"),
+         2: .failure(NSError(domain: "domain", code: 44, userInfo: nil)),
+         3: .idle()]
     }
 
     var emptyTasks: KeyedEmptyTask<Int, NSError> {
-        [0: .requestRunning(),
+        [0: .running(),
          1: .requestSuccess(),
-         2: .requestFailure(NSError(domain: "domain", code: 44, userInfo: nil)),
-         3: .requestIdle()]
+         2: .failure(NSError(domain: "domain", code: 44, userInfo: nil)),
+         3: .idle()]
     }
 
     func test_subscript() {

--- a/Tests/KeyedTaskTests.swift
+++ b/Tests/KeyedTaskTests.swift
@@ -11,7 +11,7 @@ class KeyedTaskTests: XCTestCase {
 
     var emptyTasks: KeyedEmptyTask<Int, NSError> {
         [0: .running(),
-         1: .requestSuccess(),
+         1: .success(),
          2: .failure(NSError(domain: "domain", code: 44, userInfo: nil)),
          3: .idle()]
     }

--- a/Tests/PublishersTests.swift
+++ b/Tests/PublishersTests.swift
@@ -3,12 +3,12 @@ import Combine
 import XCTest
 
 class PublishersTests: XCTestCase {
-    var taskSuccess1: Task<String, TestError> = .requestSuccess("hola")
-    var taskSuccess2: Task<String, TestError> = .requestSuccess("chau")
-    var taskFailure1: Task<String, TestError> = .requestFailure(.berenjenaError)
-    var taskFailure2: Task<String, TestError> = .requestFailure(.bigBerenjenaError)
-    var taskRunning1: Task<String, TestError> = .requestRunning()
-    var taskIdle1: Task<String, TestError> = .requestIdle()
+    var taskSuccess1: Task<String, TestError> = .success("hola")
+    var taskSuccess2: Task<String, TestError> = .success("chau")
+    var taskFailure1: Task<String, TestError> = .failure(.berenjenaError)
+    var taskFailure2: Task<String, TestError> = .failure(.bigBerenjenaError)
+    var taskRunning1: Task<String, TestError> = .running()
+    var taskIdle1: Task<String, TestError> = .idle()
 
     // Tuple2
 

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -5,7 +5,7 @@ class TaskTests: XCTestCase {
     let error = NSError(domain: "wawa", code: 69, userInfo: nil)
 
     func test_check_states_for_running_task() {
-        let task = Task<Int, NSError>.requestRunning()
+        let task: Task<Int, NSError> = .running()
 
         XCTAssertEqual(task.status, .running)
         XCTAssertNil(task.error)
@@ -18,7 +18,7 @@ class TaskTests: XCTestCase {
     }
 
     func test_check_states_for_success_task() {
-        let task = Task<Int, NSError>(status: .success(payload: 5))
+        let task: Task<Int, NSError> = .success(5)
 
         XCTAssertEqual(task.status, .success(payload: 5))
         XCTAssertEqual(task.payload, 5)
@@ -31,7 +31,7 @@ class TaskTests: XCTestCase {
     }
 
     func test_check_states_for_failure_task() {
-        let task = Task<String, NSError>.requestFailure(error)
+        let task: Task<String, NSError> = .failure(error)
 
         XCTAssertEqual(task.status, .failure(error: error))
         XCTAssertNil(task.payload)
@@ -47,30 +47,30 @@ class TaskTests: XCTestCase {
     func test_data_and_progress() {
         let payload = "comiendo perritos calientes"
         let progress: Decimal = 0.5
-        let task = Task<String, TestError>(status: .success(payload: payload), progress: progress)
+        let task: Task<String, TestError> = .success(payload, progress: progress)
 
         XCTAssertEqual(task.payload, payload)
         XCTAssertEqual(task.progress, progress)
     }
 
     func test_success_task_with_payload() {
-        let task = Task<String, TestError>(status: .success(payload: "hola"))
+        let task: Task<String, TestError> = .success("hola")
 
         XCTAssertEqual(task.payload, "hola")
     }
 
     func test_expiration_of_task_created_with_past_date() {
-        let task = Task<String, NSError>(status: .success(payload: "55"), started: Date.distantPast)
+        let task: Task<String, NSError> = .success("55", started: Date.distantPast)
         XCTAssertFalse(task.isRecentlySucceeded)
     }
 
     func test_success_task_with_expiration_setted_to_immediately() {
-        let task = Task<Int, NSError>.requestSuccess(6, expiration: .immediately)
+        let task: Task<Int, NSError> = .success(6, expiration: .immediately)
         XCTAssertFalse(task.isRecentlySucceeded)
     }
 
     func test_success_task_with_expiration_setted() {
-        let task = Task<Int, NSError>.requestSuccess(66, expiration: .custom(2))
+        let task: Task<Int, NSError> = .success(66, expiration: .custom(2))
         XCTAssertTrue(task.isRecentlySucceeded)
 
         Thread.sleep(forTimeInterval: 3)


### PR DESCRIPTION
### PR's key points
- Renamed: 
  - .requestIdle to .idle
  - .requestRunning to .running
  - .requestFailure to .failure
  - .requestSuccess to .sucess
- Removed obsolete code

### How to review this PR?
Check tests

